### PR TITLE
Add patch that increases the profile metadata limit from 4 to 8

### DIFF
--- a/patches/008_increase_profile_metadata_limit.patch
+++ b/patches/008_increase_profile_metadata_limit.patch
@@ -1,0 +1,22 @@
+diff --git a/app/models/account.rb b/app/models/account.rb
+index a25ebc4aa..75f1c2575 100644
+--- a/app/models/account.rb
++++ b/app/models/account.rb
+@@ -101,7 +101,7 @@ class Account < ApplicationRecord
+   validates_with UnreservedUsernameValidator, if: -> { local? && will_save_change_to_username? && actor_type != 'Application' }
+   validates :display_name, length: { maximum: 30 }, if: -> { local? && will_save_change_to_display_name? }
+   validates :note, note_length: { maximum: 500 }, if: -> { local? && will_save_change_to_note? }
+-  validates :fields, length: { maximum: 4 }, if: -> { local? && will_save_change_to_fields? }
++  validates :fields, length: { maximum: 8 }, if: -> { local? && will_save_change_to_fields? }
+   validates :uri, absence: true, if: :local?, on: :create
+   validates :inbox_url, absence: true, if: :local?, on: :create
+   validates :shared_inbox_url, absence: true, if: :local?, on: :create
+@@ -344,7 +344,7 @@ class Account < ApplicationRecord
+     self[:fields] = fields
+   end
+ 
+-  DEFAULT_FIELDS_SIZE = 4
++  DEFAULT_FIELDS_SIZE = 8
+ 
+   def build_fields
+     return if fields.size >= DEFAULT_FIELDS_SIZE


### PR DESCRIPTION
This is so that local users can set more profile metadata. For remote users it seems like all the profile metadata is already displayed anyway.